### PR TITLE
Autostart executable at script startup

### DIFF
--- a/notify_media.lua
+++ b/notify_media.lua
@@ -149,6 +149,21 @@ end
 
 mp.set_property("options/input-ipc-server", "\\\\.\\pipe\\mpvsocket_" .. pid)
 
+--This runs the executable at start of the script automatically.
+REL_EXE_LOCATION = "MPVMediaControl.exe" --Name of the exe file in the script directory
+script_dir = mp.get_script_directory()
+exe_path = script_dir .. "/" .. REL_EXE_LOCATION
+mp.msg.info("Starting MPV-SMTC executable")
+mp.command_native({
+    name = "subprocess",
+    playback_only = false,
+    capture_stdout = false,
+    detach = true,
+    args = {
+        exe_path
+    },
+})
+
 mp.register_event("file-loaded", notify_current_file)
 mp.observe_property("metadata", nil, notify_metadata_updated)
 mp.observe_property("chapter", nil, notify_metadata_updated)

--- a/notify_media.lua
+++ b/notify_media.lua
@@ -153,7 +153,7 @@ mp.set_property("options/input-ipc-server", "\\\\.\\pipe\\mpvsocket_" .. pid)
 REL_EXE_LOCATION = "MPVMediaControl.exe" --Name of the exe file in the script directory
 script_dir = mp.get_script_directory()
 exe_path = script_dir .. "/" .. REL_EXE_LOCATION
-mp.msg.info("Starting MPV-SMTC executable")
+mp.msg.info("Starting MPVMediaControl executable")
 mp.command_native({
     name = "subprocess",
     playback_only = false,


### PR DESCRIPTION
To make this work tho we need to create a folder which contains both the script and the executable and rename the script as main.lua.